### PR TITLE
Add sibling probability rule

### DIFF
--- a/src/pedigree.js
+++ b/src/pedigree.js
@@ -61,6 +61,22 @@ export class Pedigree {
                 individual.calculateFromParents();
             }
         }
+
+        for (const child of this.individuals) {
+            if (child.affected && child.parents.length === 2) {
+                const [parent1, parent2] = child.parents;
+                const siblings = parent1.children.filter(c =>
+                    parent2.children.includes(c) && c !== child
+                );
+                for (const sib of siblings) {
+                    if (!sib.affected) {
+                        sib.probabilities = [0, 0.25, 0.25, 0.5];
+                        sib.validateAndNormalizeProbabilities();
+                        sib.originalProbabilities = [...sib.probabilities];
+                    }
+                }
+            }
+        }
     }
 
     calculateNegativeLogLikelihood() {

--- a/tests/sibling_condition.test.js
+++ b/tests/sibling_condition.test.js
@@ -1,0 +1,22 @@
+import { Pedigree } from '../src/pedigree.js';
+
+test('siblings of an affected child have 50% chance of the condition and 0% neg-neg', () => {
+    const pedigree = new Pedigree('cf');
+    const father = pedigree.addIndividual('M');
+    const mother = pedigree.addIndividual('F');
+    pedigree.addPartnership(father, mother);
+
+    const affected = pedigree.addIndividual('M');
+    affected.setAffected(true);
+    pedigree.addParentChild(father, affected);
+    pedigree.addParentChild(mother, affected);
+
+    const sibling = pedigree.addIndividual('M');
+    pedigree.addParentChild(father, sibling);
+    pedigree.addParentChild(mother, sibling);
+
+    pedigree.updateAllProbabilities();
+
+    expect(sibling.probabilities[3]).toBeCloseTo(0.5);
+    expect(sibling.probabilities[0]).toBeCloseTo(0);
+});


### PR DESCRIPTION
## Summary
- define sibling probabilities after inferring parents from an affected child
- add regression test for sibling probabilities when a child is affected

## Testing
- `NODE_OPTIONS=--experimental-vm-modules npm test`

------
https://chatgpt.com/codex/tasks/task_e_684abc07099c832590f680f6449b2d84