### PR TITLE
Add command line pedigree optimizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,27 @@ Install dependencies and run the automated tests:
 npm install
 NODE_OPTIONS=--experimental-vm-modules npm test
 ```
+
+## Command Line Usage
+
+Run the optimiser on a pedigree defined in a JSON file:
+
+```bash
+node cli.js pedigree.json 123 5000
+```
+
+This expects `pedigree.json` to contain a structure like:
+
+```json
+{
+  "condition": "cf",
+  "individuals": [
+    {"id": 1, "gender": "M", "race": "general"},
+    {"id": 2, "gender": "F", "race": "general"},
+    {"id": 3, "gender": "M", "parents": [1,2], "affected": true}
+  ]
+}
+```
+
+The program prints a table of updated genotype probabilities for each
+individual.

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+import fs from 'fs';
+import { Pedigree } from './src/pedigree.js';
+import { Optimizer } from './src/optimizer.js';
+
+function mulberry32(a) {
+  return function() {
+    var t = a += 0x6D2B79F5;
+    t = Math.imul(t ^ t >>> 15, 1 | t);
+    t = t + Math.imul(t ^ t >>> 7, 61 | t) ^ t;
+    return ((t ^ t >>> 14) >>> 0) / 4294967296;
+  }
+}
+
+function setRandomSeed(seed) {
+  const prng = mulberry32(seed >>> 0);
+  Math.random = prng;
+}
+
+function parsePedigree(filePath) {
+  const json = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+  const condition = json.condition || 'cf';
+  const pedigree = new Pedigree(condition);
+  const map = new Map();
+  for (const info of json.individuals) {
+    const ind = pedigree.addIndividual(info.gender);
+    map.set(info.id, ind);
+    if (info.affected) ind.setAffected(true);
+    if (info.race) ind.setRace(info.race, condition);
+  }
+  for (const info of json.individuals) {
+    if (info.parents) {
+      const child = map.get(info.id);
+      if (info.parents[0]) {
+        pedigree.addParentChild(map.get(info.parents[0]), child);
+      }
+      if (info.parents[1]) {
+        pedigree.addParentChild(map.get(info.parents[1]), child);
+      }
+      if (info.parents.length === 2) {
+        pedigree.addPartnership(map.get(info.parents[0]), map.get(info.parents[1]));
+      }
+    }
+  }
+  return pedigree;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  if (args.length < 1) {
+    console.error('Usage: node cli.js <file> [seed] [iterations]');
+    process.exit(1);
+  }
+  const file = args[0];
+  const seed = args.length > 1 ? parseInt(args[1], 10) : Date.now();
+  const iters = args.length > 2 ? parseInt(args[2], 10) : 10000;
+  setRandomSeed(seed);
+  const pedigree = parsePedigree(file);
+  pedigree.updateAllProbabilities();
+  const optimizer = new Optimizer(pedigree);
+  optimizer.run(iters);
+  for (const ind of pedigree.individuals) {
+    const probs = ind.probabilities.map(p => p.toFixed(4)).join('\t');
+    console.log(`${ind.id}\t${probs}`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "genetics-calculators",
   "version": "1.0.0",
   "type": "module",
+  "bin": {
+    "pedigree-opt": "./cli.js"
+  },
   "scripts": {
     "test": "node --experimental-vm-modules node_modules/.bin/jest"
   },


### PR DESCRIPTION
## Summary
- add `cli.js` providing a command line interface to run the optimizer
- expose CLI via `package.json`
- document how to use the CLI in README

## Testing
- `npm install`
- `NODE_OPTIONS=--experimental-vm-modules npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ad18d029c8325bb5292574bee2a8f