### PR TITLE
Add CLI scenarios for hypothetical relatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,15 @@ This expects `pedigree.json` to contain a structure like:
   "individuals": [
     {"id": 1, "gender": "M", "race": "general"},
     {"id": 2, "gender": "F", "race": "general"},
-    {"id": 3, "gender": "M", "parents": [1,2], "affected": true}
+    {"id": 3, "gender": "M", "parents": [1,2], "affected": true},
+    {"id": 4, "gender": "F", "parents": [1,2], "hypothetical": true}
   ]
 }
 ```
 
-The program prints a table of updated genotype probabilities for each
-individual.
+Individuals may include a `hypothetical` flag to indicate that they are
+not yet born. Such individuals are excluded from the likelihood
+calculation but their genotype probabilities are computed from their
+parents. The program prints a table of updated genotype probabilities
+for each individual, including any hypothetical children.
+Sample pedigrees that demonstrate these features can be found in the `scenarios` directory.

--- a/cli.js
+++ b/cli.js
@@ -27,6 +27,7 @@ function parsePedigree(filePath) {
     map.set(info.id, ind);
     if (info.affected) ind.setAffected(true);
     if (info.race) ind.setRace(info.race, condition);
+    if (info.hypothetical) ind.hypothetical = true;
   }
   for (const info of json.individuals) {
     if (info.parents) {

--- a/scenarios/hypothetical_child_with_afflicted_cousin.json
+++ b/scenarios/hypothetical_child_with_afflicted_cousin.json
@@ -1,0 +1,13 @@
+{
+  "condition": "cf",
+  "individuals": [
+    {"id": 1, "gender": "M", "race": "general"},
+    {"id": 2, "gender": "F", "race": "general"},
+    {"id": 3, "gender": "M", "parents": [1, 2]},
+    {"id": 4, "gender": "F", "parents": [1, 2]},
+    {"id": 5, "gender": "F", "race": "general"},
+    {"id": 6, "gender": "M", "parents": [3, 5], "affected": true},
+    {"id": 7, "gender": "M", "race": "general"},
+    {"id": 8, "gender": "F", "parents": [4, 7], "hypothetical": true}
+  ]
+}

--- a/scenarios/hypothetical_child_with_afflicted_sibling.json
+++ b/scenarios/hypothetical_child_with_afflicted_sibling.json
@@ -1,0 +1,9 @@
+{
+  "condition": "cf",
+  "individuals": [
+    {"id": 1, "gender": "M", "race": "general"},
+    {"id": 2, "gender": "F", "race": "general"},
+    {"id": 3, "gender": "M", "parents": [1, 2], "affected": true},
+    {"id": 4, "gender": "F", "parents": [1, 2], "hypothetical": true}
+  ]
+}

--- a/src/pedigree.js
+++ b/src/pedigree.js
@@ -82,6 +82,7 @@ export class Pedigree {
     calculateNegativeLogLikelihood() {
         let logLikelihood = 0;
         for (const individual of this.individuals) {
+            if (individual.hypothetical) continue;
             if (individual.affected) {
                 const prob = individual.probabilities[3];
                 logLikelihood += Math.log(prob > 0 ? prob : 1e-10);

--- a/tests/hypothetical_child.test.js
+++ b/tests/hypothetical_child.test.js
@@ -1,0 +1,26 @@
+import { Pedigree } from '../src/pedigree.js';
+
+test('hypothetical child does not affect likelihood', () => {
+    const ped1 = new Pedigree('cf');
+    const f1 = ped1.addIndividual('M');
+    const m1 = ped1.addIndividual('F');
+    ped1.addPartnership(f1, m1);
+    ped1.updateAllProbabilities();
+    const llWithout = ped1.calculateNegativeLogLikelihood();
+
+    const ped2 = new Pedigree('cf');
+    const f2 = ped2.addIndividual('M');
+    const m2 = ped2.addIndividual('F');
+    ped2.addPartnership(f2, m2);
+    const child = ped2.addIndividual('M');
+    child.hypothetical = true;
+    ped2.addParentChild(f2, child);
+    ped2.addParentChild(m2, child);
+    ped2.updateAllProbabilities();
+    const llWith = ped2.calculateNegativeLogLikelihood();
+
+    expect(llWith).toBeCloseTo(llWithout);
+    expect(child.probabilities[0]).toBeCloseTo(0.25);
+    expect(child.probabilities[3]).toBeCloseTo(0.25);
+});
+


### PR DESCRIPTION
## Summary
- provide example JSON pedigrees for CLI usage
- reference new `scenarios` directory in README

## Testing
- `npm install`
- `NODE_OPTIONS=--experimental-vm-modules npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ad87a88408325a1eb88e9486422ae