### PR TITLE
Add pedigree layout utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,22 @@ calculation but their genotype probabilities are computed from their
 parents. The program prints a table of updated genotype probabilities
 for each individual, including any hypothetical children.
 Sample pedigrees that demonstrate these features can be found in the `scenarios` directory.
+
+### JSON Pedigree Format
+
+A pedigree file contains a `condition` and an array of `individuals`.  Each
+individual can include the following properties:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | number | Unique identifier used for references. |
+| `gender` | `'M'` or `'F'` | Sex of the individual. |
+| `parents` | `[id,id]` | (optional) IDs of the parents. |
+| `race` | string | (optional) Population used for base carrier frequency. |
+| `affected` | boolean | (optional) Mark as affected. |
+| `hypothetical` | boolean | (optional) Exclude from likelihood calculations. |
+| `x`/`y` | number | (optional) Display coordinates for editors. |
+
+Coordinates are optional and allow visual tools to store the layout of the
+pedigree.  They are ignored by the optimiser but preserved when reading and
+writing files.

--- a/layout-cli.js
+++ b/layout-cli.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+import { readPedigree, writePedigree } from './src/io.js';
+import { autoLayout } from './src/layout.js';
+
+function main() {
+    const args = process.argv.slice(2);
+    if (args.length < 1) {
+        console.error('Usage: node layout-cli.js <input> [output]');
+        process.exit(1);
+    }
+    const input = args[0];
+    const output = args[1] || input;
+
+    const pedigree = readPedigree(input);
+    autoLayout(pedigree);
+    writePedigree(pedigree, output, true);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+    main();
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "type": "module",
   "bin": {
-    "pedigree-opt": "./cli.js"
+    "pedigree-opt": "./cli.js",
+    "pedigree-layout": "./layout-cli.js"
   },
   "scripts": {
     "test": "node --experimental-vm-modules node_modules/.bin/jest"

--- a/src/io.js
+++ b/src/io.js
@@ -1,0 +1,63 @@
+import fs from 'fs';
+import { Pedigree } from './pedigree.js';
+
+export function parsePedigreeObject(obj) {
+    const condition = obj.condition || 'cf';
+    const pedigree = new Pedigree(condition);
+    const map = new Map();
+    for (const info of obj.individuals) {
+        const ind = pedigree.addIndividual(info.gender);
+        map.set(info.id, ind);
+        if (info.affected) ind.setAffected(true);
+        if (info.race) ind.setRace(info.race, condition);
+        if (info.hypothetical) ind.hypothetical = true;
+        if (typeof info.x === 'number') ind.x = info.x;
+        if (typeof info.y === 'number') ind.y = info.y;
+    }
+    for (const info of obj.individuals) {
+        if (info.parents) {
+            const child = map.get(info.id);
+            if (info.parents[0]) {
+                pedigree.addParentChild(map.get(info.parents[0]), child);
+            }
+            if (info.parents[1]) {
+                pedigree.addParentChild(map.get(info.parents[1]), child);
+            }
+            if (info.parents.length === 2) {
+                pedigree.addPartnership(map.get(info.parents[0]), map.get(info.parents[1]));
+            }
+        }
+    }
+    return pedigree;
+}
+
+export function readPedigree(filePath) {
+    const json = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    return parsePedigreeObject(json);
+}
+
+export function pedigreeToObject(pedigree, includeCoords = false) {
+    const individuals = pedigree.individuals.map(ind => {
+        const obj = {
+            id: ind.id,
+            gender: ind.gender,
+        };
+        if (ind.parents.length === 2) {
+            obj.parents = [ind.parents[0].id, ind.parents[1].id];
+        }
+        if (ind.race) obj.race = ind.race;
+        if (ind.affected) obj.affected = true;
+        if (ind.hypothetical) obj.hypothetical = true;
+        if (includeCoords) {
+            if (typeof ind.x === 'number') obj.x = ind.x;
+            if (typeof ind.y === 'number') obj.y = ind.y;
+        }
+        return obj;
+    });
+    return { condition: pedigree.condition, individuals };
+}
+
+export function writePedigree(pedigree, filePath, includeCoords = false) {
+    const obj = pedigreeToObject(pedigree, includeCoords);
+    fs.writeFileSync(filePath, JSON.stringify(obj, null, 2));
+}

--- a/src/layout.js
+++ b/src/layout.js
@@ -1,0 +1,60 @@
+export function autoLayout(pedigree, options = {}) {
+    const xSpacing = options.xSpacing || 120;
+    const ySpacing = options.ySpacing || 100;
+
+    const levelMap = new Map();
+    const queue = [];
+
+    for (const ind of pedigree.individuals) {
+        if (ind.parents.length === 0) {
+            levelMap.set(ind, 0);
+            queue.push(ind);
+        }
+    }
+
+    while (queue.length) {
+        const ind = queue.shift();
+        const level = levelMap.get(ind);
+        for (const child of ind.children) {
+            const childLevel = level + 1;
+            if (!levelMap.has(child) || childLevel > levelMap.get(child)) {
+                levelMap.set(child, childLevel);
+                queue.push(child);
+            }
+        }
+    }
+
+    const groups = new Map();
+    for (const [ind, lvl] of levelMap.entries()) {
+        if (!groups.has(lvl)) groups.set(lvl, []);
+        groups.get(lvl).push(ind);
+    }
+
+    const levels = Array.from(groups.keys()).sort((a, b) => a - b);
+    for (const lvl of levels) {
+        const inds = groups.get(lvl);
+        inds.sort((a, b) => a.id - b.id);
+
+        // keep partners adjacent
+        const ordered = [];
+        const used = new Set();
+        for (const ind of inds) {
+            if (used.has(ind)) continue;
+            if (ind.partner && inds.includes(ind.partner)) {
+                ordered.push(ind, ind.partner);
+                used.add(ind);
+                used.add(ind.partner);
+            } else {
+                ordered.push(ind);
+                used.add(ind);
+            }
+        }
+
+        let x = 0;
+        for (const ind of ordered) {
+            ind.x = x;
+            ind.y = lvl * ySpacing;
+            x += xSpacing;
+        }
+    }
+}

--- a/tests/io_and_layout.test.js
+++ b/tests/io_and_layout.test.js
@@ -1,0 +1,38 @@
+import { parsePedigreeObject, pedigreeToObject } from '../src/io.js';
+import { autoLayout } from '../src/layout.js';
+import { Pedigree } from '../src/pedigree.js';
+
+/** Verify that coordinates are parsed and written */
+test('parse and write coordinates', () => {
+    const obj = {
+        condition: 'cf',
+        individuals: [
+            { id: 1, gender: 'M', x: 10, y: 20 },
+            { id: 2, gender: 'F' }
+        ]
+    };
+    const ped = parsePedigreeObject(obj);
+    expect(ped.individuals[0].x).toBe(10);
+    expect(ped.individuals[0].y).toBe(20);
+
+    const out = pedigreeToObject(ped, true);
+    expect(out.individuals[0].x).toBe(10);
+    expect(out.individuals[0].y).toBe(20);
+});
+
+/** Basic check that autoLayout assigns generation based y */
+test('autoLayout assigns coordinates', () => {
+    const ped = new Pedigree('cf');
+    const f = ped.addIndividual('M');
+    const m = ped.addIndividual('F');
+    ped.addPartnership(f, m);
+    const c = ped.addIndividual('M');
+    ped.addParentChild(f, c);
+    ped.addParentChild(m, c);
+
+    autoLayout(ped, { xSpacing: 50, ySpacing: 40 });
+
+    expect(f.y).toBe(0);
+    expect(m.y).toBe(0);
+    expect(c.y).toBe(40);
+});


### PR DESCRIPTION
## Summary
- document the pedigree JSON format and coordinates
- refactor CLI to use new IO helpers
- implement pedigree IO helpers
- implement automatic layout library and CLI
- add tests for new features

## Testing
- `npm install` *(fails: Service Unavailable)*
- `NODE_OPTIONS=--experimental-vm-modules npm test` *(fails: cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_684b26b5535c8325b6659aea8091b912