### PR TITLE
Fix sibling probabilities and colourized output

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -31,9 +31,23 @@ function main() {
   pedigree.updateAllProbabilities();
   const optimizer = new Optimizer(pedigree);
   optimizer.run(iters);
+  console.log('[Person]\t[Clear]\t[--------Carrier------]\t[Affected]');
   for (const ind of pedigree.individuals) {
-    const probs = ind.probabilities.map(p => p.toFixed(4)).join('\t');
-    console.log(`${ind.id}\t${probs}`);
+    const clear = ind.probabilities[0].toFixed(4);
+    const c1 = ind.probabilities[1];
+    const c2 = ind.probabilities[2];
+    const carrierTotal = c1 + c2;
+    let carrierStr = `${c1.toFixed(4)}+${c2.toFixed(4)}=${carrierTotal.toFixed(4)}`;
+    let affectedStr = ind.probabilities[3].toFixed(4);
+
+    if (carrierTotal > 0.75) {
+      carrierStr = `\x1b[33m${carrierStr}\x1b[0m`;
+    }
+    if (ind.probabilities[3] > 0.75) {
+      affectedStr = `\x1b[31m${affectedStr}\x1b[0m`;
+    }
+
+    console.log(`${ind.id}\t${clear}\t${carrierStr}\t${affectedStr}`);
   }
 }
 

--- a/envsetup.sh
+++ b/envsetup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Install node dependencies for the genetics-calculators project
+# Used by automated environments to prepare for testing
+npm install

--- a/src/pedigree.js
+++ b/src/pedigree.js
@@ -70,8 +70,12 @@ export class Pedigree {
                 );
                 for (const sib of siblings) {
                     if (!sib.affected) {
-                        sib.probabilities = [0, 0.25, 0.25, 0.5];
-                        sib.validateAndNormalizeProbabilities();
+                        // Recompute the sibling probabilities from the
+                        // now-obligate carrier parents rather than assuming
+                        // a fixed distribution. This correctly yields a
+                        // 25% chance of being affected for hypothetical
+                        // children.
+                        sib.calculateFromParents();
                         sib.originalProbabilities = [...sib.probabilities];
                     }
                 }

--- a/tests/hypothetical_child.test.js
+++ b/tests/hypothetical_child.test.js
@@ -82,4 +82,26 @@ test('hypothetical child does not affect likelihood', () => {
     expect(child.probabilities[3]).toBeCloseTo(0.25);
 });
 
+test('hypothetical child with affected sibling has 25% affected risk', () => {
+    const ped = new Pedigree('cf');
+    const f = ped.addIndividual('M');
+    const m = ped.addIndividual('F');
+    ped.addPartnership(f, m);
+
+    const affected = ped.addIndividual('M');
+    affected.setAffected(true);
+    ped.addParentChild(f, affected);
+    ped.addParentChild(m, affected);
+
+    const hypo = ped.addIndividual('F');
+    hypo.hypothetical = true;
+    ped.addParentChild(f, hypo);
+    ped.addParentChild(m, hypo);
+
+    ped.updateAllProbabilities();
+
+    expect(hypo.probabilities[3]).toBeCloseTo(0.25);
+    expect(hypo.probabilities[0]).toBeCloseTo(0.25);
+});
+
 

--- a/tests/sibling_condition.test.js
+++ b/tests/sibling_condition.test.js
@@ -1,6 +1,6 @@
 import { Pedigree } from '../src/pedigree.js';
 
-test('siblings of an affected child have 50% chance of the condition and 0% neg-neg', () => {
+test('siblings of an affected child have 25% chance of the condition', () => {
     const pedigree = new Pedigree('cf');
     const father = pedigree.addIndividual('M');
     const mother = pedigree.addIndividual('F');
@@ -17,6 +17,6 @@ test('siblings of an affected child have 50% chance of the condition and 0% neg-
 
     pedigree.updateAllProbabilities();
 
-    expect(sibling.probabilities[3]).toBeCloseTo(0.5);
-    expect(sibling.probabilities[0]).toBeCloseTo(0);
+    expect(sibling.probabilities[3]).toBeCloseTo(0.25);
+    expect(sibling.probabilities[0]).toBeCloseTo(0.25);
 });


### PR DESCRIPTION
## Summary
- recompute sibling probabilities so unaffected siblings of an affected child have 25% risk
- show headers and combined carrier column in CLI output with colours for high‑probability carriers and affected
- regression test for hypothetical child with affected sibling
- add envsetup.sh for installing npm dependencies

## Testing
- `npm test`
- `node cli.js scenarios/hypothetical_child_with_afflicted_sibling.json`


------
https://chatgpt.com/codex/tasks/task_e_684bca6d0b74832599979d8727d2bfd9