### PR TITLE
Add sanity checks for parent count

### DIFF
--- a/script.js
+++ b/script.js
@@ -656,17 +656,28 @@
              * @param {Individual} child
              */
             addParentChild(parent, child) {
-                // Prevent adding if would create cycles or if child already has 2 parents
-                if (child.parents.length >= 2) {
+                if (!parent || !child) {
+                    alert("Parent or child missing");
+                    return;
+                }
+                if (parent === child) {
+                    alert("An individual cannot be their own parent");
+                    return;
+                }
+                if (child.parents.length >= 2 && !child.parents.includes(parent)) {
                     alert("Child already has two parents!");
                     return;
                 }
-                
+
                 if (!child.parents.includes(parent)) {
                     child.parents.push(parent);
                 }
                 if (!parent.children.includes(child)) {
                     parent.children.push(child);
+                }
+                if (child.parents.length > 2) {
+                    alert("Child cannot have more than two parents!");
+                    return;
                 }
                 this.relations.push({type: 'parent', parent: parent, child: child});
             }

--- a/src/io.js
+++ b/src/io.js
@@ -16,12 +16,19 @@ export function parsePedigreeObject(obj) {
     }
     for (const info of obj.individuals) {
         if (info.parents) {
+            if (info.parents.length > 2) {
+                throw new Error(`Individual ${info.id} has more than two parents`);
+            }
             const child = map.get(info.id);
             if (info.parents[0]) {
-                pedigree.addParentChild(map.get(info.parents[0]), child);
+                const p1 = map.get(info.parents[0]);
+                if (!p1) throw new Error(`Missing parent ${info.parents[0]} for individual ${info.id}`);
+                pedigree.addParentChild(p1, child);
             }
             if (info.parents[1]) {
-                pedigree.addParentChild(map.get(info.parents[1]), child);
+                const p2 = map.get(info.parents[1]);
+                if (!p2) throw new Error(`Missing parent ${info.parents[1]} for individual ${info.id}`);
+                pedigree.addParentChild(p2, child);
             }
             if (info.parents.length === 2) {
                 pedigree.addPartnership(map.get(info.parents[0]), map.get(info.parents[1]));

--- a/src/pedigree.js
+++ b/src/pedigree.js
@@ -15,7 +15,13 @@ export class Pedigree {
     }
 
     addParentChild(parent, child) {
-        if (child.parents.length >= 2) {
+        if (!parent || !child) {
+            throw new Error('Parent or child missing');
+        }
+        if (parent === child) {
+            throw new Error('Individual cannot be their own parent');
+        }
+        if (child.parents.length >= 2 && !child.parents.includes(parent)) {
             throw new Error('Child already has two parents');
         }
         if (!child.parents.includes(parent)) {
@@ -23,6 +29,9 @@ export class Pedigree {
         }
         if (!parent.children.includes(child)) {
             parent.children.push(child);
+        }
+        if (child.parents.length > 2) {
+            throw new Error('Child cannot have more than two parents');
         }
         this.relations.push({ type: 'parent', parent, child });
     }

--- a/tests/sanity_parents.test.js
+++ b/tests/sanity_parents.test.js
@@ -1,0 +1,16 @@
+import { parsePedigreeObject } from '../src/io.js';
+
+// Ensure parsePedigreeObject throws when an individual lists more than two parents
+
+test('rejects individuals with more than two parents', () => {
+    const obj = {
+        condition: 'cf',
+        individuals: [
+            { id: 1, gender: 'M' },
+            { id: 2, gender: 'F' },
+            { id: 3, gender: 'F' },
+            { id: 4, gender: 'M', parents: [1,2,3] }
+        ]
+    };
+    expect(() => parsePedigreeObject(obj)).toThrow(/more than two parents/);
+});


### PR DESCRIPTION
## Summary
- validate parent count when parsing pedigrees
- disallow invalid parent-child relationships
- guard the browser version against too many parents
- test for invalid parent count

## Testing
- `NODE_OPTIONS=--experimental-vm-modules npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684bdbd491488325942c6f153f2440dc