### PR TITLE
Refactor optimizer to reuse shared module

### DIFF
--- a/pedigree_analyzer.html
+++ b/pedigree_analyzer.html
@@ -75,6 +75,6 @@
         </div>
     </div>
 
-    <script src="script.js"></script>
+    <script type="module" src="script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load browser code as ES module
- reuse shared optimizer from `src` instead of duplicated logic
- keep same UI but import shared population data and optimizer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cddbecec483258892bee4bc42e382