### PR TITLE
Add partner arrays and reciprocal sanity checks

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -1,0 +1,20 @@
+name: Scenario Sanity Check
+
+on:
+  push:
+    paths:
+      - 'scenarios/**'
+  pull_request:
+    paths:
+      - 'scenarios/**'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm install
+      - run: npm run sanity

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "test": "node --experimental-vm-modules node_modules/.bin/jest",
-    "build": "node build.js"
+    "build": "node build.js",
+    "sanity": "node scripts/sanity_check.js"
   },
   "devDependencies": {
     "esbuild": "^0.25.5",

--- a/pedigree_analyzer.html
+++ b/pedigree_analyzer.html
@@ -68,7 +68,8 @@
                 <div>Negative Log-Likelihood: <span id="likelihood">0.000</span></div>
                 <div>Status: <span id="optStatus">Ready</span></div>
             </div>
-            
+            <div id="dataErrors" style="color:#d00;margin-top:4px"></div>
+
             <div class="individual-info" id="individualInfo">
                 Click on an individual to see details
             </div>

--- a/scenarios/hypothetical_child_with_afflicted_cousin.json
+++ b/scenarios/hypothetical_child_with_afflicted_cousin.json
@@ -1,13 +1,13 @@
 {
   "condition": "cf",
   "individuals": [
-    {"id": 1, "gender": "M", "race": "general"},
-    {"id": 2, "gender": "F", "race": "general"},
-    {"id": 3, "gender": "M", "parents": [1, 2]},
-    {"id": 4, "gender": "F", "parents": [1, 2]},
-    {"id": 5, "gender": "F", "race": "general"},
+    {"id": 1, "gender": "M", "race": "general", "is_sexual_partner_of": [2]},
+    {"id": 2, "gender": "F", "race": "general", "is_sexual_partner_of": [1]},
+    {"id": 3, "gender": "M", "parents": [1, 2], "is_sexual_partner_of": [5]},
+    {"id": 4, "gender": "F", "parents": [1, 2], "is_sexual_partner_of": [7]},
+    {"id": 5, "gender": "F", "race": "general", "is_sexual_partner_of": [3]},
     {"id": 6, "gender": "M", "parents": [3, 5], "affected": true},
-    {"id": 7, "gender": "M", "race": "general"},
+    {"id": 7, "gender": "M", "race": "general", "is_sexual_partner_of": [4]},
     {"id": 8, "gender": "F", "parents": [4, 7], "hypothetical": true}
   ]
 }

--- a/scenarios/hypothetical_child_with_afflicted_sibling.json
+++ b/scenarios/hypothetical_child_with_afflicted_sibling.json
@@ -1,8 +1,8 @@
 {
   "condition": "cf",
   "individuals": [
-    {"id": 1, "gender": "M", "race": "general"},
-    {"id": 2, "gender": "F", "race": "general"},
+    {"id": 1, "gender": "M", "race": "general", "is_sexual_partner_of": [2]},
+    {"id": 2, "gender": "F", "race": "general", "is_sexual_partner_of": [1]},
     {"id": 3, "gender": "M", "parents": [1, 2], "affected": true},
     {"id": 4, "gender": "F", "parents": [1, 2], "hypothetical": true}
   ]

--- a/scripts/sanity_check.js
+++ b/scripts/sanity_check.js
@@ -1,0 +1,21 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { sanityCheckPedigreeObject } from '../src/io.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const scenariosDir = path.join(__dirname, '..', 'scenarios');
+
+for (const file of fs.readdirSync(scenariosDir)) {
+  if (!file.endsWith('.json')) continue;
+  const filePath = path.join(scenariosDir, file);
+  const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+  try {
+    sanityCheckPedigreeObject(data);
+    console.log(`✓ ${file}`);
+  } catch (err) {
+    console.error(`Sanity check failed for ${file}: ${err.message}`);
+    process.exit(1);
+  }
+}
+console.log('All scenario files passed sanity check');

--- a/tests/io_and_layout.test.js
+++ b/tests/io_and_layout.test.js
@@ -7,8 +7,8 @@ test('parse and write coordinates', () => {
     const obj = {
         condition: 'cf',
         individuals: [
-            { id: 1, gender: 'M', x: 10, y: 20 },
-            { id: 2, gender: 'F' }
+            { id: 1, gender: 'M', x: 10, y: 20, is_sexual_partner_of: [2] },
+            { id: 2, gender: 'F', is_sexual_partner_of: [1] }
         ]
     };
     const ped = parsePedigreeObject(obj);
@@ -18,6 +18,8 @@ test('parse and write coordinates', () => {
     const out = pedigreeToObject(ped, true);
     expect(out.individuals[0].x).toBe(10);
     expect(out.individuals[0].y).toBe(20);
+    expect(out.individuals[0].is_sexual_partner_of).toEqual([2]);
+    expect(out.individuals[1].is_sexual_partner_of).toEqual([1]);
 });
 
 /** Basic check that autoLayout assigns generation based y */

--- a/tests/sanity_partner.test.js
+++ b/tests/sanity_partner.test.js
@@ -1,0 +1,20 @@
+import { sanityCheckPedigreeObject } from '../src/io.js';
+
+const good = {
+    condition: 'cf',
+    individuals: [
+        { id: 1, gender: 'M', race: 'general', is_sexual_partner_of: [2] },
+        { id: 2, gender: 'F', race: 'general', is_sexual_partner_of: [1] },
+        { id: 3, gender: 'M', parents: [1, 2] }
+    ]
+};
+
+test('sanity check passes with reciprocal partner links', () => {
+    expect(() => sanityCheckPedigreeObject(good)).not.toThrow();
+});
+
+test('sanity check fails when partner link missing', () => {
+    const bad = JSON.parse(JSON.stringify(good));
+    delete bad.individuals[0].is_sexual_partner_of;
+    expect(() => sanityCheckPedigreeObject(bad)).toThrow(/Partner link/);
+});


### PR DESCRIPTION
## Summary
- allow `is_sexual_partner_of` to be a list of partner ids
- verify each entry is reciprocated in `sanityCheckPedigreeObject`
- parse and write partner arrays in scenario JSON
- update scenarios and tests for new format

## Testing
- `NODE_OPTIONS=--experimental-vm-modules npm test`
- `node scripts/sanity_check.js`


------
https://chatgpt.com/codex/tasks/task_e_684d29d9401883258939d40bf1f73c8b