### PR TITLE
Display probabilities to 4 decimals and use fixed learning rate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,11 +71,8 @@ The "Add Child" button allows creating children for selected parent pairs:
 5. Hypothetical children are visually distinguished (dashed borders) and excluded from likelihood calculations
 
 ### Optimization Engine
-Uses simulated annealing with several improvements:
-- **Increased step size**: `changeAmount = 0.05` (increased from 0.01) for more meaningful probability changes
-- **Adaptive cooling**: Temperature reduction adapts based on progress:
-  - Fast progress (< 100 iterations without improvement): Normal cooling rate (0.995)
-  - Slow progress (100-500 iterations): Slower cooling (0.9995)  
-  - No progress (> 500 iterations): Minimal cooling (0.9999) to maintain exploration
+Uses simulated annealing with a simple cooling schedule:
+- **Learning rate**: `changeAmount = 0.0001` for small probability adjustments
+- **Constant cooling**: Temperature decreases by the fixed `coolingRate` every step
 - **Proper likelihood calculation**: Hypothetical children excluded from optimization target
 - Both accepted and rejected moves increment no-improvement counter for better convergence detection

--- a/script.js
+++ b/script.js
@@ -629,7 +629,7 @@ class Individual extends BaseIndividual {
                 const info = document.getElementById('individualInfo');
                 if (this.selectedIndividual) {
                     const ind = this.selectedIndividual;
-                    const probs = ind.probabilities.map(p => p.toFixed(3)).join(', ');
+                    const probs = ind.probabilities.map(p => p.toFixed(4)).join(', ');
                     
                     info.innerHTML = `
                         <strong>Individual ${ind.id} (${ind.gender === 'M' ? 'Male' : 'Female'})</strong><br>
@@ -655,10 +655,10 @@ class Individual extends BaseIndividual {
                         <div style="font-size: 12px;">
                             <strong>Genotype Probabilities:</strong><br>
                             <div style="font-family: monospace; background: #f8f9fa; padding: 5px; border-radius: 3px;">
-                                neg-neg: ${ind.probabilities[0].toFixed(3)}<br>
-                                neg-pos: ${ind.probabilities[1].toFixed(3)}<br>
-                                pos-neg: ${ind.probabilities[2].toFixed(3)}<br>
-                                pos-pos: ${ind.probabilities[3].toFixed(3)}
+                                neg-neg: ${ind.probabilities[0].toFixed(4)}<br>
+                                neg-pos: ${ind.probabilities[1].toFixed(4)}<br>
+                                pos-neg: ${ind.probabilities[2].toFixed(4)}<br>
+                                pos-pos: ${ind.probabilities[3].toFixed(4)}
                             </div>
                         </div>
                         ${ind.parents.length > 0 ? `<div style="margin-top: 10px; font-size: 12px; color: #666;">Parents: ${ind.parents.map(p => p.id).join(', ')}</div>` : ''}
@@ -833,7 +833,7 @@ class Individual extends BaseIndividual {
                 
                 // Draw probabilities
                 this.ctx.font = '8px Arial';
-                const probs = individual.probabilities.map(p => p.toFixed(2));
+                const probs = individual.probabilities.map(p => p.toFixed(4));
                 this.ctx.fillText(`${probs[0]} ${probs[1]}`, x, y - 30);
                 this.ctx.fillText(`${probs[2]} ${probs[3]}`, x, y - 22);
                 

--- a/src/optimizer.js
+++ b/src/optimizer.js
@@ -7,6 +7,7 @@ export class Optimizer {
         this.noImprovementCount = 0;
         this.temperature = 1.0;
         this.coolingRate = 0.995;
+        this.learningRate = 0.0001;
     }
 
     initialize() {
@@ -26,7 +27,7 @@ export class Optimizer {
         }
         const individual = unaffected[Math.floor(Math.random() * unaffected.length)];
         const originalProbs = [...individual.probabilities];
-        const changeAmount = 0.05;
+        const changeAmount = this.learningRate;
         if (Math.random() < 0.5) {
             const change = (Math.random() - 0.5) * changeAmount;
             individual.probabilities[0] = Math.max(0, Math.min(1, individual.probabilities[0] + change));
@@ -76,17 +77,8 @@ export class Optimizer {
         }
         this.iterations++;
         
-        // Adaptive cooling: only cool down if we're making progress
-        if (this.noImprovementCount < 100) {
-            // Making progress - cool down normally
-            this.temperature *= this.coolingRate;
-        } else if (this.noImprovementCount < 500) {
-            // Slow progress - cool down more slowly
-            this.temperature *= 0.9995;
-        } else {
-            // No progress - maintain temperature for exploration
-            this.temperature *= 0.9999;
-        }
+        // Constant cooling with fixed rate
+        this.temperature *= this.coolingRate;
         return true;
     }
 

--- a/tests/optimization_improvements.test.js
+++ b/tests/optimization_improvements.test.js
@@ -2,7 +2,7 @@ import { jest } from "@jest/globals";
 import { Pedigree } from '../src/pedigree.js';
 import { Optimizer } from '../src/optimizer.js';
 
-test('optimizer with improved parameters should work with larger step sizes', () => {
+test('optimizer works with small learning rate', () => {
     const pedigree = new Pedigree('cf');
     
     // Create individuals that will produce a meaningful likelihood
@@ -42,52 +42,19 @@ test('optimizer with improved parameters should work with larger step sizes', ()
     expect(optimizer.iterations).toBeGreaterThan(0);
 });
 
-test('adaptive cooling should maintain temperature when not improving', () => {
+test('temperature always cools by fixed rate', () => {
     const pedigree = new Pedigree('cf');
     const father = pedigree.addIndividual('M');
     father.setRace('general', 'cf');
-    
-    const optimizer = new Optimizer(pedigree);
-    optimizer.initialize();
-    
-    // Manually test the cooling logic by setting noImprovementCount high
-    optimizer.noImprovementCount = 600;
-    const initialTemp = optimizer.temperature;
-    
-    // Manually apply the cooling logic (replicated from the source)
-    if (optimizer.noImprovementCount < 100) {
-        optimizer.temperature *= optimizer.coolingRate;
-    } else if (optimizer.noImprovementCount < 500) {
-        optimizer.temperature *= 0.9995;
-    } else {
-        optimizer.temperature *= 0.9999;
-    }
-    
-    // Temperature should barely decrease (0.9999 factor)
-    const expectedTemp = initialTemp * 0.9999;
-    expect(optimizer.temperature).toBeCloseTo(expectedTemp, 6);
-});
 
-test('adaptive cooling should cool normally when improving', () => {
-    const pedigree = new Pedigree('cf');
-    const father = pedigree.addIndividual('M');
-    father.setRace('general', 'cf'); // Need race for optimization to work
-    
     const optimizer = new Optimizer(pedigree);
     optimizer.initialize();
-    
+
     const initialTemp = optimizer.temperature;
-    
-    // Simulate good progress scenario
-    optimizer.noImprovementCount = 50; // Low count = making progress
-    
-    // Perform a single step
+
     const stepped = optimizer.performSingleStep();
-    
-    // Should have performed a step
     expect(stepped).toBe(true);
-    
-    // Temperature should decrease by normal cooling rate (0.995)
-    const expectedTemp = initialTemp * 0.995;
+
+    const expectedTemp = initialTemp * optimizer.coolingRate;
     expect(optimizer.temperature).toBeCloseTo(expectedTemp, 6);
 });


### PR DESCRIPTION
## Summary
- remove adaptive cooling logic
- use a new `learningRate` of `0.0001`
- draw probabilities with `toFixed(4)` in the UI
- update CLAUDE docs
- adjust optimizer tests for constant cooling

## Testing
- `npm install`
- `NODE_OPTIONS=--experimental-vm-modules npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e7edd8a348325bae452255b5062f8