### PR TITLE
Add auto partnership on second parent and UI smoke test

### DIFF
--- a/script.js
+++ b/script.js
@@ -478,6 +478,10 @@ class Individual extends BaseIndividual {
                     return;
                 }
                 this.relations.push({type: 'parent', parent: parent, child: child});
+                if (child.parents.length === 2) {
+                    const [p1, p2] = child.parents;
+                    this.addPartnership(p1, p2);
+                }
             }
             
             /**
@@ -1144,6 +1148,8 @@ class Optimizer {
             const canvas = document.getElementById('pedigreeCanvas');
             pedigreeChart = new PedigreeChart(canvas);
             optimizer = new Optimizer(pedigreeChart);
+            window.pedigreeChart = pedigreeChart;
+            window.optimizer = optimizer;
 
             // Set up event listeners
             document.getElementById('conditionSelect').addEventListener('change', updateFrequencyTable);

--- a/src/pedigree.js
+++ b/src/pedigree.js
@@ -34,6 +34,10 @@ export class Pedigree {
             throw new Error('Child cannot have more than two parents');
         }
         this.relations.push({ type: 'parent', parent, child });
+        if (child.parents.length === 2) {
+            const [p1, p2] = child.parents;
+            this.addPartnership(p1, p2);
+        }
     }
 
     addPartnership(ind1, ind2) {

--- a/tests/selenium_partner_smoke.test.js
+++ b/tests/selenium_partner_smoke.test.js
@@ -1,0 +1,60 @@
+import { jest } from '@jest/globals';
+import { Builder, By, until } from 'selenium-webdriver';
+import firefox from 'selenium-webdriver/firefox.js';
+import { spawnSync } from 'child_process';
+import path from 'path';
+
+jest.setTimeout(30000);
+
+test('partner link added when child has two parents', async () => {
+  const build = spawnSync('node', ['build.js']);
+  expect(build.status).toBe(0);
+
+  const options = new firefox.Options();
+  options.addArguments('-headless');
+  const service = new firefox.ServiceBuilder('/usr/local/bin/geckodriver');
+  const driver = await new Builder()
+    .forBrowser('firefox')
+    .setFirefoxOptions(options)
+    .setFirefoxService(service)
+    .build();
+
+  try {
+    const fileUrl = 'file://' + path.resolve('dist/pedigree_analyzer.html');
+    await driver.get(fileUrl);
+
+    const canvas = await driver.findElement(By.id('pedigreeCanvas'));
+
+    // Add first male
+    await driver.findElement(By.id('addMaleBtn')).click();
+    await driver.actions().move({origin: canvas, x: 100, y: 100}).click().perform();
+
+    // Add female
+    await driver.findElement(By.id('addFemaleBtn')).click();
+    await driver.actions().move({origin: canvas, x: 200, y: 100}).click().perform();
+
+    // Add second male
+    await driver.findElement(By.id('addMaleBtn')).click();
+    await driver.actions().move({origin: canvas, x: 150, y: 200}).click().perform();
+
+    // male1 parent of male2
+    await driver.findElement(By.id('addRelationBtn')).click();
+    await driver.actions().move({origin: canvas, x: 100, y: 100}).click().perform();
+    await driver.actions().move({origin: canvas, x: 150, y: 200}).click().perform();
+    await driver.wait(until.elementLocated(By.id('rel-parent')), 5000);
+    await driver.findElement(By.id('rel-parent')).click();
+
+    // female parent of male2
+    await driver.actions().move({origin: canvas, x: 200, y: 100}).click().perform();
+    await driver.actions().move({origin: canvas, x: 150, y: 200}).click().perform();
+    await driver.wait(until.elementLocated(By.id('rel-parent')), 5000);
+    await driver.findElement(By.id('rel-parent')).click();
+
+    const partnerId = await driver.executeScript(
+      'return window.pedigreeChart.individuals[0].partner && window.pedigreeChart.individuals[0].partner.id;'
+    );
+    expect(partnerId).toBe(2);
+  } finally {
+    await driver.quit();
+  }
+});

--- a/tests/selenium_partner_smoke.test.js
+++ b/tests/selenium_partner_smoke.test.js
@@ -12,7 +12,10 @@ test('partner link added when child has two parents', async () => {
 
   const options = new firefox.Options();
   options.addArguments('-headless');
-  const service = new firefox.ServiceBuilder('/usr/local/bin/geckodriver');
+  const geckodriverPath = process.env.GECKOWEBDRIVER
+    ? path.join(process.env.GECKOWEBDRIVER, 'geckodriver')
+    : '/usr/local/bin/geckodriver';
+  const service = new firefox.ServiceBuilder(geckodriverPath);
   const driver = await new Builder()
     .forBrowser('firefox')
     .setFirefoxOptions(options)

--- a/tests/selenium_ui.test.js
+++ b/tests/selenium_ui.test.js
@@ -12,7 +12,10 @@ test('pedigree analyzer page loads', async () => {
 
   const options = new firefox.Options();
   options.addArguments('-headless');
-  const service = new firefox.ServiceBuilder('/usr/local/bin/geckodriver');
+  const geckodriverPath = process.env.GECKOWEBDRIVER
+    ? path.join(process.env.GECKOWEBDRIVER, 'geckodriver')
+    : '/usr/local/bin/geckodriver';
+  const service = new firefox.ServiceBuilder(geckodriverPath);
   const driver = await new Builder()
     .forBrowser('firefox')
     .setFirefoxOptions(options)


### PR DESCRIPTION
## Summary
- auto-create partner link when a child gains two parents
- expose `pedigreeChart` globally for tests
- add selenium smoke test verifying partner lines appear

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f7c26134483259edab0e15e42be79