### PR TITLE
Use GECKOWEBDRIVER variable for selenium tests

### DIFF
--- a/tests/selenium_partner_smoke.test.js
+++ b/tests/selenium_partner_smoke.test.js
@@ -12,7 +12,10 @@ test('partner link added when child has two parents', async () => {
 
   const options = new firefox.Options();
   options.addArguments('-headless');
-  const service = new firefox.ServiceBuilder('/usr/local/bin/geckodriver');
+  const geckodriverPath = process.env.GECKOWEBDRIVER
+    ? path.join(process.env.GECKOWEBDRIVER, 'geckodriver')
+    : '/usr/local/bin/geckodriver';
+  const service = new firefox.ServiceBuilder(geckodriverPath);
   const driver = await new Builder()
     .forBrowser('firefox')
     .setFirefoxOptions(options)

--- a/tests/selenium_ui.test.js
+++ b/tests/selenium_ui.test.js
@@ -12,7 +12,10 @@ test('pedigree analyzer page loads', async () => {
 
   const options = new firefox.Options();
   options.addArguments('-headless');
-  const service = new firefox.ServiceBuilder('/usr/local/bin/geckodriver');
+  const geckodriverPath = process.env.GECKOWEBDRIVER
+    ? path.join(process.env.GECKOWEBDRIVER, 'geckodriver')
+    : '/usr/local/bin/geckodriver';
+  const service = new firefox.ServiceBuilder(geckodriverPath);
   const driver = await new Builder()
     .forBrowser('firefox')
     .setFirefoxOptions(options)


### PR DESCRIPTION
## Summary
- update selenium tests to read the geckodriver path from the `GECKOWEBDRIVER` environment variable

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684fb653ed3c83259c6e4a1b34199bef