### PR TITLE
Add probability delta display

### DIFF
--- a/pedigree_analyzer.html
+++ b/pedigree_analyzer.html
@@ -67,6 +67,7 @@
             <div class="optimization-status" id="optimizationStatus">
                 <div>Iterations: <span id="iterationCount">0</span></div>
                 <div>Negative Log-Likelihood: <span id="likelihood">0.000</span></div>
+                <div>Probability Delta: <span id="probDelta">0.000</span></div>
                 <div>Status: <span id="optStatus">Ready</span></div>
             </div>
             <div id="dataErrors" style="color:#d00;margin-top:4px"></div>

--- a/tests/optimization_improvements.test.js
+++ b/tests/optimization_improvements.test.js
@@ -30,12 +30,13 @@ test('optimizer works with small learning rate', () => {
     // Perform 50 optimization steps
     let stepsPerformed = 0;
     for (let i = 0; i < 50; i++) {
-        if (optimizer.performSingleStep()) {
+        const delta = optimizer.performSingleStep();
+        if (delta !== null) {
             stepsPerformed++;
         }
     }
-    
-    // Should have performed steps
+
+    // Should have attempted steps
     expect(stepsPerformed).toBeGreaterThan(0);
     
     // Should have completed some iterations
@@ -53,8 +54,9 @@ test('temperature always cools by fixed rate', () => {
     const initialTemp = optimizer.temperature;
 
     const stepped = optimizer.performSingleStep();
-    expect(stepped).toBe(true);
+    expect(stepped).not.toBeNull();
 
     const expectedTemp = initialTemp * optimizer.coolingRate;
     expect(optimizer.temperature).toBeCloseTo(expectedTemp, 6);
 });
+

--- a/tests/selenium_step_once_smoke.test.js
+++ b/tests/selenium_step_once_smoke.test.js
@@ -1,0 +1,64 @@
+import { jest } from '@jest/globals';
+import { Builder, By } from 'selenium-webdriver';
+import firefox from 'selenium-webdriver/firefox.js';
+import { spawnSync } from 'child_process';
+import path from 'path';
+
+jest.setTimeout(30000);
+
+test('step node updates genotype table', async () => {
+  const build = spawnSync('node', ['build.js']);
+  expect(build.status).toBe(0);
+
+  const options = new firefox.Options();
+  options.addArguments('-headless');
+  const geckodriverPath = process.env.GECKOWEBDRIVER
+    ? path.join(process.env.GECKOWEBDRIVER, 'geckodriver')
+    : '/usr/local/bin/geckodriver';
+  const service = new firefox.ServiceBuilder(geckodriverPath);
+  const driver = await new Builder()
+    .forBrowser('firefox')
+    .setFirefoxOptions(options)
+    .setFirefoxService(service)
+    .build();
+
+  try {
+    const fileUrl = 'file://' + path.resolve('dist/pedigree_analyzer.html');
+    await driver.get(fileUrl);
+
+    const fileInput = await driver.findElement(By.id('loadFileInput'));
+    const scenarioPath = path.resolve('scenarios/hypothetical_child_with_afflicted_sibling.json');
+    await fileInput.sendKeys(scenarioPath);
+    await driver.sleep(500);
+
+    await driver.findElement(By.id('selectBtn')).click();
+    await driver.executeScript(
+      'pedigreeChart.selectedIndividual = pedigreeChart.individuals.find(i => i.id === 1); if (pedigreeChart) { pedigreeChart.updateIndividualInfo(); }'
+    );
+    await driver.sleep(100);
+
+    const before = await driver.executeScript(
+      'return pedigreeChart.selectedIndividual.probabilities.slice();'
+    );
+
+    const stepBtn = await driver.findElement(By.id('stepNodeBtn'));
+    let delta = 0;
+    for (let i = 0; i < 20; i++) {
+      await stepBtn.click();
+      await driver.sleep(50);
+      const txt = await driver.findElement(By.id('probDelta')).getText();
+      delta = parseFloat(txt);
+      if (delta > 0) break;
+    }
+    await driver.sleep(100);
+
+    const after = await driver.executeScript(
+      'return pedigreeChart.selectedIndividual.probabilities.slice();'
+    );
+
+    expect(after).not.toEqual(before);
+    expect(delta).toBeGreaterThan(0);
+  } finally {
+    await driver.quit();
+  }
+});


### PR DESCRIPTION
## Summary
- show last step's probability delta under optimization controls
- return probability change from optimizer and update display after each step
- use Step Node in Selenium smoke test and check delta
- adapt optimizer unit tests for new return value

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850192b047083258bc7ce6cdd414d2b