### PR TITLE
Add Powell optimizer across all founders

### DIFF
--- a/src/optimjs.js
+++ b/src/optimjs.js
@@ -46,3 +46,63 @@ export function optimizeFounderPowell(pedigree, individual) {
     pedigree.updateAllProbabilities();
     return result.fncvalue;
 }
+
+/**
+ * Optimize genotype probabilities for all founders simultaneously using Powell's method.
+ * Returns the final negative log-likelihood.
+ * @param {Pedigree} pedigree
+ */
+export function optimizeAllFoundersPowell(pedigree) {
+    const founders = pedigree.individuals.filter(ind =>
+        !ind.affected && !ind.frozen && ind.parents.length === 0
+    );
+    if (founders.length === 0) {
+        return null;
+    }
+
+    const baseline = pedigree.individuals.map(ind => [...ind.probabilities]);
+    const start = [];
+    for (const f of founders) {
+        start.push(f.probabilities[0]);
+        start.push((f.probabilities[1] + f.probabilities[2]) / 2);
+    }
+
+    function objective(x) {
+        for (let i = 0; i < founders.length; i++) {
+            const pAA = x[2 * i];
+            const pCarrier = x[2 * i + 1];
+            if (pAA < 0 || pCarrier < 0 || pAA + 2 * pCarrier > 1) {
+                return Number.POSITIVE_INFINITY;
+            }
+        }
+
+        for (let i = 0; i < pedigree.individuals.length; i++) {
+            pedigree.individuals[i].probabilities = [...baseline[i]];
+        }
+        for (let i = 0; i < founders.length; i++) {
+            const pAA = x[2 * i];
+            const pCarrier = x[2 * i + 1];
+            founders[i].probabilities = [pAA, pCarrier, pCarrier, 1 - pAA - 2 * pCarrier];
+        }
+        pedigree.updateAllProbabilities();
+        return pedigree.calculateNegativeLogLikelihood();
+    }
+
+    const result = minimize_Powell(objective, start);
+    const best = result.argument;
+    for (let i = 0; i < founders.length; i++) {
+        const pAA = best[2 * i];
+        const pCarrier = best[2 * i + 1];
+        if (!(pAA < 0 || pCarrier < 0 || pAA + 2 * pCarrier > 1)) {
+            founders[i].probabilities = [pAA, pCarrier, pCarrier, 1 - pAA - 2 * pCarrier];
+            founders[i].validateAndNormalizeProbabilities();
+        }
+    }
+    for (let i = 0; i < pedigree.individuals.length; i++) {
+        if (!founders.includes(pedigree.individuals[i])) {
+            pedigree.individuals[i].probabilities = [...baseline[i]];
+        }
+    }
+    pedigree.updateAllProbabilities();
+    return result.fncvalue;
+}

--- a/tests/optimjs_powell_all.test.js
+++ b/tests/optimjs_powell_all.test.js
@@ -1,0 +1,23 @@
+import { Pedigree } from '../src/pedigree.js';
+import { optimizeAllFoundersPowell } from '../src/optimjs.js';
+
+// Ensure simultaneous Powell optimization runs and improves likelihood
+
+test('Powell optimizer decreases negative log-likelihood for all founders', () => {
+    const pedigree = new Pedigree('cf');
+    const father = pedigree.addIndividual('M');
+    father.setRace('general', 'cf');
+    const mother = pedigree.addIndividual('F');
+    mother.setRace('general', 'cf');
+    pedigree.addPartnership(father, mother);
+
+    const child = pedigree.addIndividual('M');
+    child.setAffected(true);
+    pedigree.addParentChild(father, child);
+    pedigree.addParentChild(mother, child);
+
+    pedigree.updateAllProbabilities();
+    const start = pedigree.calculateNegativeLogLikelihood();
+    const end = optimizeAllFoundersPowell(pedigree);
+    expect(end).toBeLessThanOrEqual(start);
+});


### PR DESCRIPTION
## Summary
- support optimizing all founders simultaneously with Powell's method
- use Powell optimizer for each single optimization step
- test simultaneous founder optimization

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6851729c22588325af62e1e098e04151