### PR TITLE
Add selenium test for predefined scenario loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ calculation but their genotype probabilities are computed from their
 parents. The program prints a table of updated genotype probabilities
 for each individual, including any hypothetical children.
 Sample pedigrees that demonstrate these features can be found in the `scenarios` directory.
+The web UI includes a **Load Example** drop‑down that loads these sample files without needing to upload them.
 
 ### JSON Pedigree Format
 

--- a/pedigree_analyzer.html
+++ b/pedigree_analyzer.html
@@ -26,6 +26,10 @@
                 <button id="clearBtn">Clear All</button>
                 <input type="file" id="loadFileInput" accept=".json" style="display:none">
                 <button id="loadFileBtn">Load File</button>
+                <select id="scenarioSelect">
+                    <option value="">Load Example...</option>
+                </select>
+                <button id="loadScenarioBtn">Load Example</button>
                 <button id="saveFileBtn">Save File</button>
             </div>
         </div>

--- a/predefined_scenarios.js
+++ b/predefined_scenarios.js
@@ -1,0 +1,24 @@
+export const predefinedScenarios = {
+  "Hypothetical Child with Afflicted Cousin": {
+    "condition": "cf",
+    "individuals": [
+      {"id": 1, "gender": "M", "race": "general", "is_sexual_partner_of": [2]},
+      {"id": 2, "gender": "F", "race": "general", "is_sexual_partner_of": [1]},
+      {"id": 3, "gender": "M", "parents": [1, 2], "is_sexual_partner_of": [5]},
+      {"id": 4, "gender": "F", "parents": [1, 2], "is_sexual_partner_of": [7]},
+      {"id": 5, "gender": "F", "race": "general", "is_sexual_partner_of": [3]},
+      {"id": 6, "gender": "M", "parents": [3, 5], "affected": true},
+      {"id": 7, "gender": "M", "race": "general", "is_sexual_partner_of": [4]},
+      {"id": 8, "gender": "F", "parents": [4, 7], "hypothetical": true}
+    ]
+  },
+  "Hypothetical Child with Afflicted Sibling": {
+    "condition": "cf",
+    "individuals": [
+      {"id": 1, "gender": "M", "race": "general", "is_sexual_partner_of": [2], "x": 100, "y": 50},
+      {"id": 2, "gender": "F", "race": "general", "is_sexual_partner_of": [1], "x": 200, "y": 50},
+      {"id": 3, "gender": "M", "parents": [1, 2], "affected": true, "x": 150, "y": 150},
+      {"id": 4, "gender": "F", "parents": [1, 2], "hypothetical": true, "x": 250, "y": 150}
+    ]
+  }
+};

--- a/script.js
+++ b/script.js
@@ -1,6 +1,7 @@
 import { Individual as BaseIndividual } from './src/individual.js';
 import { Optimizer as BaseOptimizer } from './src/optimizer.js';
 import { probabilityToFraction } from './src/probability_fraction.js';
+import { predefinedScenarios } from './predefined_scenarios.js';
 
 class Individual extends BaseIndividual {
     constructor(x, y, gender, id) {
@@ -1356,6 +1357,21 @@ class Optimizer {
                     }
                 };
                 reader.readAsText(file);
+            });
+
+            const scenarioSelect = document.getElementById('scenarioSelect');
+            for (const name of Object.keys(predefinedScenarios)) {
+                const opt = document.createElement('option');
+                opt.value = name;
+                opt.textContent = name;
+                scenarioSelect.appendChild(opt);
+            }
+
+            document.getElementById('loadScenarioBtn').addEventListener('click', () => {
+                const name = scenarioSelect.value;
+                if (name && predefinedScenarios[name]) {
+                    pedigreeChart.loadFromObject(predefinedScenarios[name]);
+                }
             });
 
             document.getElementById('saveFileBtn').addEventListener('click', () => {

--- a/tests/selenium_predefined_scenario.test.js
+++ b/tests/selenium_predefined_scenario.test.js
@@ -1,0 +1,42 @@
+import { jest } from '@jest/globals';
+import { Builder, By } from 'selenium-webdriver';
+import firefox from 'selenium-webdriver/firefox.js';
+import { spawnSync } from 'child_process';
+import path from 'path';
+
+jest.setTimeout(30000);
+
+test('predefined scenario loads from dropdown', async () => {
+  const build = spawnSync('node', ['build.js']);
+  expect(build.status).toBe(0);
+
+  const options = new firefox.Options();
+  options.addArguments('-headless');
+  const geckodriverPath = process.env.GECKOWEBDRIVER
+    ? path.join(process.env.GECKOWEBDRIVER, 'geckodriver')
+    : '/usr/local/bin/geckodriver';
+  const service = new firefox.ServiceBuilder(geckodriverPath);
+  const driver = await new Builder()
+    .forBrowser('firefox')
+    .setFirefoxOptions(options)
+    .setFirefoxService(service)
+    .build();
+
+  try {
+    const fileUrl = 'file://' + path.resolve('dist/pedigree_analyzer.html');
+    await driver.get(fileUrl);
+    const option = await driver.findElement(By.css('#scenarioSelect option[value="Hypothetical Child with Afflicted Sibling"]'));
+    await option.click();
+    await driver.findElement(By.id('loadScenarioBtn')).click();
+    await driver.sleep(500);
+    const count = await driver.executeScript('return window.pedigreeChart.individuals.length;');
+    expect(count).toBe(4);
+    const coords = await driver.executeScript(
+      'var ind=pedigreeChart.individuals.find(i=>i.id===1); return {x:ind.x,y:ind.y};'
+    );
+    expect(coords.x).toBe(100);
+    expect(coords.y).toBe(50);
+  } finally {
+    await driver.quit();
+  }
+});


### PR DESCRIPTION
## Summary
- add selenium test covering Load Example dropdown

## Testing
- `NODE_OPTIONS=--experimental-vm-modules npm test`


------
https://chatgpt.com/codex/tasks/task_e_6861b6d5984883258a414446714dc09c